### PR TITLE
mounting licence and database config outside of volume - non persistent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     image: chemaxon/jchem_webservices:latest
     volumes:
       - cxn_home:/usr/local/tomcat/.chemaxon/
-    
+      - ./license.cxl:/usr/local/tomcat/.chemaxon/license.cxl
+      - ./ws-config.xml:/usr/local/tomcat/.chemaxon/ws-config.xml
+          
 volumes:
   cxn_home:


### PR DESCRIPTION
When you want to change license (and possibly db config) you need to delete whole persistent cxn_volume. After this change, both files are mounted as non persistent, so you can switch license only by swapping files on host and the rest of the files in volume is kept.